### PR TITLE
[FEAT] 요약본 저장 시 이름, 날짜 형태 자동 지정 기능 구현

### DIFF
--- a/src/pages/SamplePage.jsx
+++ b/src/pages/SamplePage.jsx
@@ -56,11 +56,23 @@ const SamplePage = () => {
   }, [topK, topics]);
 
   const handleCreateCard = () => {
+    // 현재 날짜와 시간을 형식에 맞게 생성
+    const now = new Date();
+    const formattedDate = `${now.getFullYear()}.${String(
+      now.getMonth() + 1
+    ).padStart(2, "0")}.${String(now.getDate()).padStart(2, "0")} ${String(
+      now.getHours()
+    ).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+
+    // topics를 기반으로 제목 구성
+    const topicsTitle = topics ? `${topics.join(", ")}_요약본` : "요약본";
+
     const newCard = {
       id: cards.length + 1, // 카드 ID 생성
-      title: "새로운 카드 제목", // 기본 제목
-      date: new Date().toLocaleDateString(), // 현재 날짜
+      title: `${topicsTitle}`, // topics 기반 제목 생성
+      date: formattedDate, // 생성된 날짜 및 시간
       pdfUrl: summaryPDF, // PDF URL
+      topics: topics || [], // topics 추가
     };
 
     handleAddCard(newCard); // 새로운 카드 추가
@@ -69,8 +81,16 @@ const SamplePage = () => {
   const handleAddCard = (newCard) => {
     setCards((prevCards) => {
       const updatedCards = [...prevCards, newCard]; // 새로운 카드 추가
+
+      // 시간 기준으로 역순 정렬
+      updatedCards.sort((a, b) => {
+        const dateA = new Date(a.date);
+        const dateB = new Date(b.date);
+        return dateB - dateA; // 최신순 정렬
+      });
+
       localStorage.setItem("cards", JSON.stringify(updatedCards)); // localStorage에 카드 저장
-      console.log("새로운 카드 추가:", newCard); // 콘솔에 카드 정보 출력
+
       return updatedCards;
     });
   };

--- a/src/pages/UserPageSample.jsx
+++ b/src/pages/UserPageSample.jsx
@@ -12,10 +12,20 @@ const UserPageSample = ({ pdfUrl }) => {
   const navigate = useNavigate();
   const [cards, setCards] = useState([]);
 
+  // 시간 기준으로 역순 정렬
   useEffect(() => {
     const storedCards = localStorage.getItem("cards");
     if (storedCards) {
-      setCards(JSON.parse(storedCards)); // localStorage에서 카드 불러오기
+      const parsedCards = JSON.parse(storedCards);
+
+      // 시간 기준으로 역순 정렬
+      const sortedCards = parsedCards.sort((a, b) => {
+        const dateA = new Date(a.date);
+        const dateB = new Date(b.date);
+        return dateB - dateA; // 최신순 정렬
+      });
+
+      setCards(sortedCards); // 정렬된 데이터를 상태에 저장
     }
   }, []);
 
@@ -38,7 +48,7 @@ const UserPageSample = ({ pdfUrl }) => {
       <Header />
       <Nav>
         <ExButton variant="filled" isActive={true}>
-          요약본 추가하기
+          요약본
         </ExButton>
         <ExButton
           variant="outlined"
@@ -57,7 +67,8 @@ const UserPageSample = ({ pdfUrl }) => {
           </AddIconWrapper>
           <CardText>요약본 만들기</CardText>
         </Card>
-        {cards && cards.length > 0 ? (
+        {cards &&
+          cards.length > 0 &&
           cards.map((card) => (
             <Card key={card.id} onClick={() => handleCardClick(card.id)}>
               <DeleteButton
@@ -76,10 +87,7 @@ const UserPageSample = ({ pdfUrl }) => {
                 <DateText>{card.date}</DateText>
               </CardText>
             </Card>
-          ))
-        ) : (
-          <p>카드가 없습니다.</p>
-        )}
+          ))}
       </Content>
       <Footer />
     </Container>


### PR DESCRIPTION
## 📖개요
<br>

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 💻작업사항
- 요약본 저장 시에 이름(토픽_요약본), 날짜 자동 지정
- 마이페이지에서 요약본 네비게이트 클릭 시 글자가 "요약본 추가하기"로 바뀌던 오류 수정
- 카드가 없을 경우 출력되던 안내 문구 삭제
![image](https://github.com/user-attachments/assets/506d1fae-bebd-4e6a-bfc1-714d4bf19df2)

<br>



## 💡작성한 이슈 외에 작업한 사항
-
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?