### PR TITLE
[FEAT] 연습 문제 / 추가 연습 문제 채점 후 채점 화면 유지 기능 구현

### DIFF
--- a/src/components/LoginInputForm.jsx
+++ b/src/components/LoginInputForm.jsx
@@ -19,7 +19,7 @@ const LoginInputForm = ({
         password: userData.password,
       };
 
-      const response = await axios.post(`${API_BASE_URL}/signup/`, signUpData);
+      const response = await axios.post(`${API_BASE_URL}/signup`, signUpData);
       if (response.status === 201) {
         alert("회원가입이 완료되었습니다!");
         setCurrentType("SignIn");
@@ -56,7 +56,7 @@ const LoginInputForm = ({
         password: userData.password,
       };
 
-      const response = await axios.post(`${API_BASE_URL}/login/`, signInData);
+      const response = await axios.post(`${API_BASE_URL}/login`, signInData);
       if (response.status === 200) {
         const token = response.data.token;
         const username = signInData.username;

--- a/src/pages/CreatePracPage.jsx
+++ b/src/pages/CreatePracPage.jsx
@@ -67,7 +67,7 @@ function CreatePracPage() {
 
       const response = await axiosInstance.request({
         method: "POST",
-        url: "/pdf/upload/",
+        url: "/pdf/upload",
         data: formData,
       });
       console.log(response.data);
@@ -103,7 +103,7 @@ function CreatePracPage() {
 
     try {
       const response = await fetch(
-        "http://localhost:8000/api/question/create/",
+        "http://localhost:8000/api/question/create",
         {
           method: "POST",
           headers: {
@@ -145,7 +145,7 @@ function CreatePracPage() {
     try {
       const response = await axiosInstance.request({
         method: "POST",
-        url: "/celery/pinecone/",
+        url: "/pinecone/upload",
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/src/pages/MorePracticePage/MoreProblemContent.jsx
+++ b/src/pages/MorePracticePage/MoreProblemContent.jsx
@@ -162,7 +162,7 @@ const MoreProblemContent = ({ onButtonClick, readOnly, onProblemSolved }) => {
           console.log("Payload:", payload); // 전송 데이터 로그
 
           const { data } = await axios.post(
-            "/api/morequestion/submit-answer/",
+            "/api/morequestion/submit-answer",
             payload,
             {
               headers: {

--- a/src/pages/MorePracticePage/MoreProblemContent.jsx
+++ b/src/pages/MorePracticePage/MoreProblemContent.jsx
@@ -197,7 +197,6 @@ const MoreProblemContent = ({ onButtonClick, readOnly, onProblemSolved }) => {
         JSON.stringify(updatedTemplates)
       );
       console.log("Updated practiceTemplates:", updatedTemplates);
-      alert("채점 결과가 저장되었습니다.");
 
       const firstTopic = problems[0]?.topic || ""; // 첫 번째 문제의 topic
       console.log("Navigate로 전달되는 데이터:", {

--- a/src/pages/MorePracticePage/MoreProblemContent.jsx
+++ b/src/pages/MorePracticePage/MoreProblemContent.jsx
@@ -170,15 +170,36 @@ const MoreProblemContent = ({ onButtonClick, readOnly, onProblemSolved }) => {
               },
             }
           );
-          return {
-            ...problem, // 문제 데이터 포함
-            ...data, // API 응답 데이터 병합
+          const mergedProblem = {
+            ...problem, // 기존 문제 데이터 유지
+            ...data, // API 응답 데이터 병합 (is_answer 포함)
           };
+          console.log("Merged Problem:", mergedProblem); // 병합 결과 확인
+          return mergedProblem;
         })
       );
 
+      console.log("Final Responses:", responses); // 최종 병합된 데이터 확인
+
+      // 로컬 스토리지 업데이트
+      const storedTemplates =
+        JSON.parse(localStorage.getItem("practiceTemplates")) || [];
+      console.log("Stored Templates:", storedTemplates);
+
+      const updatedTemplates = storedTemplates.map((template) =>
+        String(template.id) === String(location.state?.templateId) // 템플릿 ID 비교
+          ? { ...template, questions: responses }
+          : template
+      );
+
+      localStorage.setItem(
+        "practiceTemplates",
+        JSON.stringify(updatedTemplates)
+      );
+      console.log("Updated practiceTemplates:", updatedTemplates);
+      alert("채점 결과가 저장되었습니다.");
+
       const firstTopic = problems[0]?.topic || ""; // 첫 번째 문제의 topic
-      console.log("First Topic:", firstTopic); // 전달될 토픽 확인
       console.log("Navigate로 전달되는 데이터:", {
         problems: responses,
         firstTopic,

--- a/src/pages/NotePage/WrongAnswer.jsx
+++ b/src/pages/NotePage/WrongAnswer.jsx
@@ -17,7 +17,7 @@ function WrongAnswer() {
   useEffect(() => {
     const fetchWrongAnswers = async () => {
       try {
-        const response = await axiosInstance.get("/question/submit-answer/");
+        const response = await axiosInstance.get("/question/submit-answer");
         setResponses(response.data); // API 응답 데이터 저장
       } catch (error) {
         console.error("오답 조회 데이터 가져오기 오류:", error);
@@ -44,7 +44,7 @@ function WrongAnswer() {
 
       // API 호출
       const response = await axiosInstance.post(
-        "/morequestion/create/",
+        "/morequestion/create",
         {
           incorrect_question_ids: responses
             .filter((response) => !response.is_correct)

--- a/src/pages/NotePage/WrongAnswer.jsx
+++ b/src/pages/NotePage/WrongAnswer.jsx
@@ -58,13 +58,20 @@ function WrongAnswer() {
       );
 
       const generatedQuestions = response.data.generated_multiple_choices;
+
+      // 각 문제에 is_answer 필드 추가
+      const updatedQuestions = generatedQuestions.map((question) => ({
+        ...question,
+        is_answer: 0, // 기본값으로 0 (채점되지 않음)
+      }));
+
       const firstTopic = generatedQuestions[0]?.topic || "추가 연습 문제";
 
       // 템플릿으로 변환 후 로컬스토리지에 저장
       const template = {
         id: new Date().toISOString(), // 고유 ID 생성
         title: `${firstTopic}_추가 연습 문제`, // 첫 번째 문제의 topic 활용
-        questions: generatedQuestions,
+        questions: updatedQuestions,
       };
 
       const existingTemplates =

--- a/src/pages/PracticeCompletePage.jsx
+++ b/src/pages/PracticeCompletePage.jsx
@@ -54,19 +54,6 @@ const PracticeCompletePage = () => {
   );
 };
 
-const LoadingModal = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(255, 255, 255, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-`;
-
 const CompletePageWrapper = styled.div`
   width: 100%;
   min-height: 100vh; /* 화면 높이를 100%로 설정 */

--- a/src/pages/PracticePage/ProblemContent.jsx
+++ b/src/pages/PracticePage/ProblemContent.jsx
@@ -160,7 +160,7 @@ const ProblemContent = ({ onButtonClick, readOnly, onProblemSolved }) => {
           console.log("Payload:", payload); // 전송 데이터 로그
 
           const { data } = await axios.post(
-            "/api/question/submit-answer/",
+            "/api/question/submit-answer",
             payload,
             {
               headers: {
@@ -182,9 +182,16 @@ const ProblemContent = ({ onButtonClick, readOnly, onProblemSolved }) => {
         firstTopic,
       });
 
+      const templateId = location.state?.templateId;
+
+      const storedResults =
+        JSON.parse(localStorage.getItem("gradingResults")) || {};
+      storedResults[templateId] = responses; // templateId로 데이터 저장
+      localStorage.setItem("gradingResults", JSON.stringify(storedResults));
+
       // 문제 데이터를 채점 결과 페이지로 전달
       navigate("/grading-results", {
-        state: { problems: responses, firstTopic },
+        state: { problems: responses, firstTopic, templateId },
       });
     } catch (error) {
       console.error("채점 중 오류 발생:", error);

--- a/src/pages/SamplePage.jsx
+++ b/src/pages/SamplePage.jsx
@@ -33,7 +33,7 @@ const SamplePage = () => {
       setIsLoading(true); // 로딩 시작
 
       try {
-        const response = await axiosInstance.post("/langchain/summary/", {
+        const response = await axiosInstance.post("/langchain/summary", {
           top_k: topK, // 숫자
           topics: topics, // 문자열 배열
         });

--- a/src/pages/UploadPage.jsx
+++ b/src/pages/UploadPage.jsx
@@ -71,7 +71,7 @@ const UploadPage = () => {
 
       const response = await axiosInstance.request({
         method: "POST",
-        url: "/pdf/upload/",
+        url: "/pdf/upload",
         data: formData,
       });
       console.log(response.data);
@@ -107,7 +107,7 @@ const UploadPage = () => {
     try {
       const response = await axiosInstance.request({
         method: "POST",
-        url: "/celery/pinecone/",
+        url: "/pinecone/upload",
         headers: {
           Authorization: `Bearer ${token}`,
         },


### PR DESCRIPTION
## 📖개요
<br>

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 💻작업사항
- 마이페이지에서 연습 문제 접속 시, 채점이 한 번이라도 된 문제라면 연습 문제 풀이 페이지가 아닌, 채점 결과가 노출 되는 기능 구현 (일반/추가 연습 문제 둘 다 구현)
<br>



## 💡작성한 이슈 외에 작업한 사항
-
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?